### PR TITLE
Feature/59498

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,18 @@
 {
-    "name": "apollo-server",
+    "name": "apollo_server",
     "version": "1.0.0",
     "description": "",
     "main": "index.js",
     "dependencies": {
+        "apollo-server": "^2.19.2",
         "apollo-server-express": "^2.19.1",
         "dotenv": "^8.2.0",
         "eslint": "^7.17.0",
         "express": "^4.17.1",
         "graphql": "^15.4.0",
-        "merge-graphql-schemas": "^1.7.8"
+        "http": "0.0.1-security",
+        "merge-graphql-schemas": "^1.7.8",
+        "module": "^1.2.5"
     },
     "devDependencies": {
         "@babel/core": "^7.12.10",

--- a/src/libs/constants.js
+++ b/src/libs/constants.js
@@ -1,0 +1,7 @@
+export default {
+  subscriptions: {
+    TRAINEE_ADDED: 'TRAINEE_ADDED',
+    TRAINEE_UPDATED: 'TRAINEE_UPDATED',
+    TRAINEE_DELETED: 'TRAINEE_DELETED'
+  }
+};

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -15,6 +15,9 @@ export default {
     },
     Mutation: {
       ...trainee.Mutation
+    },
+    Subscription: {
+      ...trainee.traineeSubscription
     }
   },
   typeDefs

--- a/src/modules/pubsub.js
+++ b/src/modules/pubsub.js
@@ -1,0 +1,5 @@
+import { PubSub } from 'apollo-server';
+
+const pubsub = new PubSub();
+
+export default pubsub;

--- a/src/modules/schema.graphql
+++ b/src/modules/schema.graphql
@@ -9,3 +9,9 @@ type Mutation {
     updateTrainee(id: ID!, role: String, name: String, email: String): User!
     deleteTrainee(id:ID!): ID!
 } 
+
+type Subscription {
+    traineeAdded: User!
+    traineeUpdated: User!
+    traineeDeleted:ID!
+}

--- a/src/modules/trainee/index.js
+++ b/src/modules/trainee/index.js
@@ -1,3 +1,4 @@
 /* eslint-disable import/prefer-default-export */
 export { default as Query } from './query';
 export { default as Mutation } from './mutation';
+export { default as traineeSubscription } from './subscription';

--- a/src/modules/trainee/mutation.js
+++ b/src/modules/trainee/mutation.js
@@ -21,7 +21,7 @@ export default {
   deleteTrainee: (parent, args, context) => {
     const { id } = args;
     const deletedID = userInstance.deleteUser(id);
-    pubsub.publish(constants.subscriptions.TRAINEE_DELETED, { traineeUpdated: deletedID });
+    pubsub.publish(constants.subscriptions.TRAINEE_DELETED, { traineeDeleted: deletedID });
     return deletedID;
   }
 };

--- a/src/modules/trainee/mutation.js
+++ b/src/modules/trainee/mutation.js
@@ -1,19 +1,27 @@
 /* eslint-disable no-unused-vars */
 import userInstance from '../../service/user';
+import pubsub from '../pubsub';
+import constants from '../../libs/constants';
 
 export default {
   createTrainee: (parent, args, context) => {
     const { user } = args;
-    return userInstance.createUser(user);
+    const addedUser = userInstance.createUser(user);
+    pubsub.publish(constants.subscriptions.TRAINEE_ADDED, { traineeAdded: addedUser });
+    return addedUser;
   },
   updateTrainee: (parent, args, context) => {
     const {
       id, role, name, email
     } = args;
-    return userInstance.updateUser(id, role, name, email);
+    const updatedUser = userInstance.updateUser(id, name, email, role);
+    pubsub.publish(constants.subscriptions.TRAINEE_UPDATED, { traineeUpdated: updatedUser });
+    return updatedUser;
   },
   deleteTrainee: (parent, args, context) => {
     const { id } = args;
-    return userInstance.deleteUser(id);
+    const deletedID = userInstance.deleteUser(id);
+    pubsub.publish(constants.subscriptions.TRAINEE_DELETED, { traineeUpdated: deletedID });
+    return deletedID;
   }
 };

--- a/src/modules/trainee/subscription.js
+++ b/src/modules/trainee/subscription.js
@@ -1,0 +1,14 @@
+import pubsub from '../pubsub';
+import constants from '../../libs/constants';
+
+export default {
+  traineeAdded: {
+    subscribe: () => pubsub.asyncIterator([constants.subscriptions.TRAINEE_ADDED])
+  },
+  traineeUpdated: {
+    subscribe: () => pubsub.asyncIterator([constants.subscriptions.TRAINEE_UPDATED])
+  },
+  traineeDeleted: {
+    subscribe: () => pubsub.asyncIterator([constants.subscriptions.TRAINEE_DELETED])
+  }
+};

--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,6 @@
 import Express from 'express';
 import { ApolloServer } from 'apollo-server-express';
+import { createServer } from 'http';
 
 class Server {
   constructor(config) {
@@ -26,13 +27,15 @@ class Server {
       ...schema
     });
     this.Server.applyMiddleware({ app });
+    this.httpServer = createServer(app);
+    this.Server.installSubscriptionHandlers(this.httpServer);
     this.run();
   }
 
   run() {
     const { config: { port } } = this;
-    const { app } = this;
-    app.listen(port, (err) => {
+    // const { app } = this;
+    this.httpServer.listen(port, (err) => {
       if (err) {
         // eslint-disable-next-line no-console
         console.log(err);

--- a/src/service/user.js
+++ b/src/service/user.js
@@ -5,7 +5,7 @@ class User {
   }
 
   getAllUsers() {
-    return this.users.values;
+    return this.users.values();
   }
 
   createUser(user) {


### PR DESCRIPTION
AC:
- Add subscriptions for add, edit and delete trainee.
- 
Prerequisites:
- Add apollo-server package
- Add subscription middleware to the apollo server.

Steps:
- Add a file called pubsub.js inside the module folder where you have to import the Pubsub class from the apollo server and 
  export its instance.
- Add the subscription type with addTrainee, updateTrainee, and deleteTrainee with return types as User for the first two and ID 
  for the last one.
- Add a file named subscription.js inside the trainee module.
- Import Pubsub instance from pubsub.js
- Define all the pubsub methods on the basis of topic.
- From your mutations publish your data, for example, publish data for created Trainee on createTrainee topic.
- The last step would be updating the server.js file so that it starts accepting WebSocket requests.
- Import createServer from the HTTP module.
- Call the create server with the express app as an argument.
- Pass the newly created server instance as an argument to the installSubscriptionsHandlers method of the apollo server i 
  instance.
- Update the run method so that it starts the server using the newly created server instance.
