### PR TITLE
Feature/58635

### DIFF
--- a/example.env
+++ b/example.env
@@ -1,1 +1,2 @@
 PORT=
+SERVICE_URL

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "",
     "main": "index.js",
     "dependencies": {
+        "apollo-datasource-rest": "^0.9.7",
         "apollo-server": "^2.19.2",
         "apollo-server-express": "^2.19.1",
         "dotenv": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -1,15 +1,18 @@
 {
-    "name": "apollo-server",
+    "name": "apollo_server",
     "version": "1.0.0",
     "description": "",
     "main": "index.js",
     "dependencies": {
+        "apollo-server": "^2.19.2",
         "apollo-server-express": "^2.19.1",
         "dotenv": "^8.2.0",
         "eslint": "^7.17.0",
         "express": "^4.17.1",
         "graphql": "^15.4.0",
-        "merge-graphql-schemas": "^1.7.8"
+        "http": "0.0.1-security",
+        "merge-graphql-schemas": "^1.7.8",
+        "module": "^1.2.5"
     },
     "devDependencies": {
         "@babel/core": "^7.12.10",

--- a/src/config/configurations.js
+++ b/src/config/configurations.js
@@ -4,6 +4,7 @@ config();
 const envVars = process.env;
 const configurations = Object.freeze({
   env: envVars.NODE_ENV,
-  port: envVars.PORT
+  port: envVars.PORT,
+  serviceUrl: envVars.SERVICE_URL
 });
 export default configurations;

--- a/src/datasource/Trainee.js
+++ b/src/datasource/Trainee.js
@@ -11,8 +11,8 @@ export default class TraineeAPI extends RESTDataSource {
     request.headers.set('authorization', this.context.token);
   }
 
-  getTrainees() {
-    return this.get('/trainee');
+  getTrainees({ skip, limit }) {
+    return this.get('/trainee', { skip, limit });
   }
 
   createTrainee(payLoad) {

--- a/src/datasource/Trainee.js
+++ b/src/datasource/Trainee.js
@@ -4,26 +4,26 @@ import configurations from '../config/configurations';
 export default class TraineeAPI extends RESTDataSource {
   constructor() {
     super();
-    this.baseURL = `${configurations.serviceUrl}/api/trainee`;
+    this.baseURL = `${configurations.serviceUrl}/api`;
   }
 
   willSendRequest(request) {
-    request.headers.set('Authorization', this.context.token);
+    request.headers.set('authorization', this.context.token);
   }
 
   getTrainees() {
     return this.get('/trainee');
   }
 
-  createTrainee(payload) {
-    return this.post('/trainee', payload);
+  createTrainee(payLoad) {
+    return this.post('/trainee', payLoad);
   }
 
-  updateTrainee() {
-    return this.put('/trainee');
+  updateTrainee(payLoad) {
+    return this.put('/trainee', payLoad);
   }
 
-  deleteTrainee() {
-    return this.delete('/trainee');
+  deleteTrainee(id) {
+    return this.delete(`/trainee?id=${id}`);
   }
 }

--- a/src/datasource/Trainee.js
+++ b/src/datasource/Trainee.js
@@ -1,0 +1,29 @@
+import { RESTDataSource } from 'apollo-datasource-rest';
+import configurations from '../config/configurations';
+
+export default class TraineeAPI extends RESTDataSource {
+  constructor() {
+    super();
+    this.baseURL = `${configurations.serviceUrl}/api/trainee`;
+  }
+
+  willSendRequest(request) {
+    request.headers.set('Authorization', this.context.token);
+  }
+
+  getTrainees() {
+    return this.get('/trainee');
+  }
+
+  createTrainee(payload) {
+    return this.post('/trainee', payload);
+  }
+
+  updateTrainee() {
+    return this.put('/trainee');
+  }
+
+  deleteTrainee() {
+    return this.delete('/trainee');
+  }
+}

--- a/src/datasource/User.js
+++ b/src/datasource/User.js
@@ -7,6 +7,10 @@ export default class UserAPI extends RESTDataSource {
     this.baseURL = `${configurations.serviceUrl}/api/user`;
   }
 
+  willSendRequest(request) {
+    request.headers.set('authorization', this.context.token);
+  }
+
   loginUser(payLoad) {
     return this.post('/login', payLoad);
   }

--- a/src/datasource/User.js
+++ b/src/datasource/User.js
@@ -1,0 +1,17 @@
+import { RESTDataSource } from 'apollo-datasource-rest';
+import configurations from '../config/configurations';
+
+export default class UserAPI extends RESTDataSource {
+  constructor() {
+    super();
+    this.baseURL = `${configurations.serviceUrl}/api/user`;
+  }
+
+  loginUser(payLoad) {
+    return this.post('/login', payLoad);
+  }
+
+  getMe() {
+    return this.get('/me');
+  }
+}

--- a/src/datasource/index.js
+++ b/src/datasource/index.js
@@ -1,0 +1,2 @@
+/* eslint-disable import/prefer-default-export */
+export { default as UserAPI } from './User';

--- a/src/datasource/index.js
+++ b/src/datasource/index.js
@@ -1,2 +1,3 @@
 /* eslint-disable import/prefer-default-export */
 export { default as UserAPI } from './User';
+export { default as TraineeAPI } from './Trainee';

--- a/src/libs/constants.js
+++ b/src/libs/constants.js
@@ -1,0 +1,7 @@
+export default {
+  subscriptions: {
+    TRAINEE_ADDED: 'TRAINEE_ADDED',
+    TRAINEE_UPDATED: 'TRAINEE_UPDATED',
+    TRAINEE_DELETED: 'TRAINEE_DELETED'
+  }
+};

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -14,7 +14,8 @@ export default {
       ...trainee.Query
     },
     Mutation: {
-      ...trainee.Mutation
+      ...trainee.Mutation,
+      ...user.Mutation
     },
     Subscription: {
       ...trainee.traineeSubscription

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -15,6 +15,9 @@ export default {
     },
     Mutation: {
       ...trainee.Mutation
+    },
+    Subscription: {
+      ...trainee.traineeSubscription
     }
   },
   typeDefs

--- a/src/modules/pubsub.js
+++ b/src/modules/pubsub.js
@@ -1,0 +1,5 @@
+import { PubSub } from 'apollo-server';
+
+const pubsub = new PubSub();
+
+export default pubsub;

--- a/src/modules/schema.graphql
+++ b/src/modules/schema.graphql
@@ -1,6 +1,6 @@
 type Query {
     getMyProfile: User!
-     getAllTrainees: [User]
+    getAllTrainees(payLoad: AlltraineesInput): Alltrainees!
     getTrainee(id: ID!): User!
 }
 

--- a/src/modules/schema.graphql
+++ b/src/modules/schema.graphql
@@ -1,6 +1,6 @@
 type Query {
     getMyProfile: User!
-    getAllTrainees(payLoad: AlltraineesInput): Alltrainees!
+    getAllTrainees(payLoad: AlltraineesInput): Alltrainees
     getTrainee(id: ID!): User!
 }
 

--- a/src/modules/schema.graphql
+++ b/src/modules/schema.graphql
@@ -7,12 +7,12 @@ type Query {
 type Mutation {
     createTrainee(payLoad: CreateUserInput): String!
     updateTrainee(payLoad: UpdateUserInput): String!
-    deleteTrainee(payLoad:DeleteUserInput): String!
+    deleteTrainee(payLoad:DeleteUserInput): Delete!
     loginUser(payLoad: LoginCredentials!): Result
 } 
 
 type Subscription {
     traineeAdded: User!
-    traineeUpdated: User!
-    traineeDeleted:ID!
+    traineeUpdated: NewRES
+    traineeDeleted:Delete!
 }

--- a/src/modules/schema.graphql
+++ b/src/modules/schema.graphql
@@ -5,10 +5,10 @@ type Query {
 }
 
 type Mutation {
-    createTrainee(user: CreateUserInput): User!
-    updateTrainee(id: ID!, role: String, name: String, email: String): User!
-    deleteTrainee(id:ID!): ID!
-    loginUser(payLoad: LoginCredentials): String
+    createTrainee(payLoad: CreateUserInput): String!
+    updateTrainee(payLoad: UpdateUserInput): String!
+    deleteTrainee(payLoad:DeleteUserInput): String!
+    loginUser(payLoad: LoginCredentials): String!
 } 
 
 type Subscription {

--- a/src/modules/schema.graphql
+++ b/src/modules/schema.graphql
@@ -8,7 +8,7 @@ type Mutation {
     createTrainee(payLoad: CreateUserInput): String!
     updateTrainee(payLoad: UpdateUserInput): String!
     deleteTrainee(payLoad:DeleteUserInput): String!
-    loginUser(payLoad: LoginCredentials): String!
+    loginUser(payLoad: LoginCredentials!): String!
 } 
 
 type Subscription {

--- a/src/modules/schema.graphql
+++ b/src/modules/schema.graphql
@@ -9,3 +9,9 @@ type Mutation {
     updateTrainee(id: ID!, role: String, name: String, email: String): User!
     deleteTrainee(id:ID!): ID!
 } 
+
+type Subscription {
+    traineeAdded: User!
+    traineeUpdated: User!
+    traineeDeleted:ID!
+}

--- a/src/modules/schema.graphql
+++ b/src/modules/schema.graphql
@@ -8,7 +8,7 @@ type Mutation {
     createTrainee(payLoad: CreateUserInput): String!
     updateTrainee(payLoad: UpdateUserInput): String!
     deleteTrainee(payLoad:DeleteUserInput): String!
-    loginUser(payLoad: LoginCredentials!): String!
+    loginUser(payLoad: LoginCredentials!): Result
 } 
 
 type Subscription {

--- a/src/modules/schema.graphql
+++ b/src/modules/schema.graphql
@@ -8,6 +8,7 @@ type Mutation {
     createTrainee(user: CreateUserInput): User!
     updateTrainee(id: ID!, role: String, name: String, email: String): User!
     deleteTrainee(id:ID!): ID!
+    loginUser(payLoad: LoginCredentials): String
 } 
 
 type Subscription {

--- a/src/modules/trainee/index.js
+++ b/src/modules/trainee/index.js
@@ -1,3 +1,4 @@
 /* eslint-disable import/prefer-default-export */
 export { default as Query } from './query';
 export { default as Mutation } from './mutation';
+export { default as traineeSubscription } from './subscription';

--- a/src/modules/trainee/mutation.js
+++ b/src/modules/trainee/mutation.js
@@ -1,27 +1,37 @@
 /* eslint-disable no-unused-vars */
-import userInstance from '../../service/user';
 import pubsub from '../pubsub';
 import constants from '../../libs/constants';
 
 export default {
-  createTrainee: (parent, args, context) => {
-    const { user } = args;
-    const addedUser = userInstance.createUser(user);
-    pubsub.publish(constants.subscriptions.TRAINEE_ADDED, { traineeAdded: addedUser });
-    return addedUser;
+  createTrainee: async (parent, args, context) => {
+    const { payLoad: { email, name, password } } = args;
+    const { dataSources: { traineeAPI } } = context;
+    const addedTrainee = await traineeAPI.createTrainee({ email, name, password });
+    const addedTraineeData = JSON.stringify(addedTrainee.data);
+    pubsub.publish(constants.subscriptions.TRAINEE_ADDED, { traineeAdded: addedTrainee.data });
+    return addedTraineeData;
   },
-  updateTrainee: (parent, args, context) => {
+  updateTrainee: async (parent, args, context) => {
     const {
-      id, role, name, email
+      payLoad: {
+        id, role, name, email, password
+      }
     } = args;
-    const updatedUser = userInstance.updateUser(id, name, email, role);
-    pubsub.publish(constants.subscriptions.TRAINEE_UPDATED, { traineeUpdated: updatedUser });
-    return updatedUser;
+    const { dataSources: { traineeAPI } } = context;
+    const updatedTrainee = await traineeAPI.updateTrainee({
+      id, name, email, role, password
+    });
+    const updatedTraineeData = JSON.stringify(updatedTrainee.data);
+    // eslint-disable-next-line max-len
+    pubsub.publish(constants.subscriptions.TRAINEE_UPDATED, { traineeUpdated: updatedTrainee.data });
+    return updatedTraineeData;
   },
-  deleteTrainee: (parent, args, context) => {
-    const { id } = args;
-    const deletedID = userInstance.deleteUser(id);
-    pubsub.publish(constants.subscriptions.TRAINEE_DELETED, { traineeDeleted: deletedID });
-    return deletedID;
+  deleteTrainee: async (parent, args, context) => {
+    const { payLoad: { id } } = args;
+    const { dataSources: { traineeAPI } } = context;
+    const deletedID = await traineeAPI.deleteTrainee(id);
+    const deletedTraineeData = JSON.stringify(deletedID);
+    pubsub.publish(constants.subscriptions.TRAINEE_DELETED, { traineeDeleted: deletedTraineeData });
+    return deletedTraineeData;
   }
 };

--- a/src/modules/trainee/mutation.js
+++ b/src/modules/trainee/mutation.js
@@ -7,6 +7,7 @@ export default {
     const { payLoad: { email, name, password } } = args;
     const { dataSources: { traineeAPI } } = context;
     const addedTrainee = await traineeAPI.createTrainee({ email, name, password });
+    console.log('sssssssssssssssssssssss', addedTrainee.data);
     const addedTraineeData = JSON.stringify(addedTrainee.data);
     pubsub.publish(constants.subscriptions.TRAINEE_ADDED, { traineeAdded: addedTrainee.data });
     return addedTraineeData;
@@ -21,17 +22,20 @@ export default {
     const updatedTrainee = await traineeAPI.updateTrainee({
       id, name, email, role, password
     });
-    const updatedTraineeData = JSON.stringify(updatedTrainee.data1);
+    console.log('333333333333333', updatedTrainee);
+    const updatedTraineeData = JSON.stringify(updatedTrainee);
     // eslint-disable-next-line max-len
-    pubsub.publish(constants.subscriptions.TRAINEE_UPDATED, { traineeUpdated: updatedTrainee.data });
+    pubsub.publish(constants.subscriptions.TRAINEE_UPDATED, { traineeUpdated: updatedTrainee });
     return updatedTraineeData;
   },
   deleteTrainee: async (parent, args, context) => {
     const { payLoad: { id } } = args;
     const { dataSources: { traineeAPI } } = context;
     const deletedID = await traineeAPI.deleteTrainee(id);
+    console.log('deletedID------', deletedID);
     const deletedTraineeData = JSON.stringify(deletedID);
-    pubsub.publish(constants.subscriptions.TRAINEE_DELETED, { traineeDeleted: deletedTraineeData });
-    return deletedTraineeData;
+    console.log('deletedTraineeData', deletedTraineeData);
+    pubsub.publish(constants.subscriptions.TRAINEE_DELETED, { traineeDeleted: deletedID });
+    return deletedID;
   }
 };

--- a/src/modules/trainee/mutation.js
+++ b/src/modules/trainee/mutation.js
@@ -21,7 +21,7 @@ export default {
   deleteTrainee: (parent, args, context) => {
     const { id } = args;
     const deletedID = userInstance.deleteUser(id);
-    pubsub.publish(constants.subscriptions.TRAINEE_DELETED, { traineeUpdated: deletedID });
+    pubsub.publish(constants.subscriptions.TRAINEE_DELETED, { traineeDeleted: deletedID });
     return deletedID;
   }
 };

--- a/src/modules/trainee/mutation.js
+++ b/src/modules/trainee/mutation.js
@@ -1,19 +1,27 @@
 /* eslint-disable no-unused-vars */
 import userInstance from '../../service/user';
+import pubsub from '../pubsub';
+import constants from '../../libs/constants';
 
 export default {
   createTrainee: (parent, args, context) => {
     const { user } = args;
-    return userInstance.createUser(user);
+    const addedUser = userInstance.createUser(user);
+    pubsub.publish(constants.subscriptions.TRAINEE_ADDED, { traineeAdded: addedUser });
+    return addedUser;
   },
   updateTrainee: (parent, args, context) => {
     const {
       id, role, name, email
     } = args;
-    return userInstance.updateUser(id, role, name, email);
+    const updatedUser = userInstance.updateUser(id, name, email, role);
+    pubsub.publish(constants.subscriptions.TRAINEE_UPDATED, { traineeUpdated: updatedUser });
+    return updatedUser;
   },
   deleteTrainee: (parent, args, context) => {
     const { id } = args;
-    return userInstance.deleteUser(id);
+    const deletedID = userInstance.deleteUser(id);
+    pubsub.publish(constants.subscriptions.TRAINEE_DELETED, { traineeUpdated: deletedID });
+    return deletedID;
   }
 };

--- a/src/modules/trainee/mutation.js
+++ b/src/modules/trainee/mutation.js
@@ -21,7 +21,7 @@ export default {
     const updatedTrainee = await traineeAPI.updateTrainee({
       id, name, email, role, password
     });
-    const updatedTraineeData = JSON.stringify(updatedTrainee.data);
+    const updatedTraineeData = JSON.stringify(updatedTrainee.data1);
     // eslint-disable-next-line max-len
     pubsub.publish(constants.subscriptions.TRAINEE_UPDATED, { traineeUpdated: updatedTrainee.data });
     return updatedTraineeData;

--- a/src/modules/trainee/query.js
+++ b/src/modules/trainee/query.js
@@ -9,6 +9,7 @@ export default {
     const { payLoad: { skip, limit } } = args;
     const { dataSources: { traineeAPI } } = context;
     const response = await traineeAPI.getTrainees({ skip, limit });
+    console.log('999999999999999', response);
     return response;
   },
   getTrainee: (parent, args) => {

--- a/src/modules/trainee/query.js
+++ b/src/modules/trainee/query.js
@@ -4,9 +4,12 @@ export default {
 
   // getAllTrainees: () => user.getAllUsers(),
   getAllTrainees: async (parent, args, context) => {
+    // const response = await traineeAPI.getTrainees();
+    // return response.record;
+    const { payLoad: { skip, limit } } = args;
     const { dataSources: { traineeAPI } } = context;
-    const response = await traineeAPI.getTrainees();
-    return response.record;
+    const response = await traineeAPI.getTrainees({ skip, limit });
+    return response;
   },
   getTrainee: (parent, args) => {
     const { id } = args;

--- a/src/modules/trainee/query.js
+++ b/src/modules/trainee/query.js
@@ -2,7 +2,12 @@ import user from '../../service/user';
 
 export default {
 
-  getAllTrainees: () => user.getAllUsers(),
+  // getAllTrainees: () => user.getAllUsers(),
+  getAllTrainees: async (parent, args, context) => {
+    const { dataSources: { traineeAPI } } = context;
+    const response = await traineeAPI.getTrainees();
+    return response.record;
+  },
   getTrainee: (parent, args) => {
     const { id } = args;
     return user.getUser(id);

--- a/src/modules/trainee/subscription.js
+++ b/src/modules/trainee/subscription.js
@@ -1,0 +1,14 @@
+import pubsub from '../pubsub';
+import constants from '../../libs/constants';
+
+export default {
+  traineeAdded: {
+    subscribe: () => pubsub.asyncIterator([constants.subscriptions.TRAINEE_ADDED])
+  },
+  traineeUpdated: {
+    subscribe: () => pubsub.asyncIterator([constants.subscriptions.TRAINEE_UPDATED])
+  },
+  traineeDeleted: {
+    subscribe: () => pubsub.asyncIterator([constants.subscriptions.TRAINEE_DELETED])
+  }
+};

--- a/src/modules/trainee/types.graphql
+++ b/src/modules/trainee/types.graphql
@@ -21,3 +21,8 @@ input LoginCredentials{
     email: String!
     password: String!
 } 
+
+input AlltraineesInput{
+    skip: Int
+    limit: Int
+}

--- a/src/modules/trainee/types.graphql
+++ b/src/modules/trainee/types.graphql
@@ -3,3 +3,8 @@ input CreateUserInput {
     email: String!
     role: String!
 } 
+
+input LoginCredentials{
+    email: String!
+    password: String!
+} 

--- a/src/modules/trainee/types.graphql
+++ b/src/modules/trainee/types.graphql
@@ -1,8 +1,21 @@
 input CreateUserInput {
     name: String!
     email: String!
+    password: String!
     role: String!
 } 
+
+input UpdateUserInput {
+    name: String
+    email: String
+    id: ID!
+    role: String
+    password: String
+}
+
+input DeleteUserInput {
+    id: ID!
+}
 
 input LoginCredentials{
     email: String!

--- a/src/modules/trainee/types.graphql
+++ b/src/modules/trainee/types.graphql
@@ -1,8 +1,7 @@
 input CreateUserInput {
-    name: String!
-    email: String!
-    password: String!
-    role: String!
+    name: String
+    email: String
+    password: String
 } 
 
 input UpdateUserInput {

--- a/src/modules/user/index.js
+++ b/src/modules/user/index.js
@@ -1,2 +1,3 @@
 /* eslint-disable import/prefer-default-export */
 export { default as Query } from './query';
+export { default as Mutation } from './mutation';

--- a/src/modules/user/mutation.js
+++ b/src/modules/user/mutation.js
@@ -3,6 +3,8 @@ export default {
     const { payLoad: { email, password } } = args;
     const { dataSources: { userAPI } } = context;
     const response = await userAPI.loginUser({ email, password });
+    console.log('responseeeee', response);
+    // const res = JSON.stringify(response);
     return response.data;
   }
 };

--- a/src/modules/user/mutation.js
+++ b/src/modules/user/mutation.js
@@ -1,0 +1,8 @@
+export default {
+  loginUser: async (parent, args, context) => {
+    const { payLoad: { email, password } } = args;
+    const { dataSources: { userAPI } } = context;
+    const response = await userAPI.loginUser({ email, password });
+    return response.data;
+  }
+};

--- a/src/modules/user/mutation.js
+++ b/src/modules/user/mutation.js
@@ -3,8 +3,6 @@ export default {
     const { payLoad: { email, password } } = args;
     const { dataSources: { userAPI } } = context;
     const response = await userAPI.loginUser({ email, password });
-    console.log('responseeeee', response);
-    // const res = JSON.stringify(response);
-    return response.data;
+    return response;
   }
 };

--- a/src/modules/user/query.js
+++ b/src/modules/user/query.js
@@ -1,8 +1,7 @@
 export default {
-  getMyProfile: () => (
-    {
-      name: 'urvashi',
-      email: 'urvashi@successive.tech',
-      id: '16290'
-    })
+  getMyProfile: async (parent, args, context) => {
+    const { dataSources: { userAPI } } = context;
+    const response = await userAPI.getMe();
+    return response.data;
+  }
 };

--- a/src/modules/user/types.graphql
+++ b/src/modules/user/types.graphql
@@ -1,9 +1,10 @@
 type User {
     name: String!
     email: String!
-    id: ID!
+    _id: ID!
     role: String
     password: String!
+    originalId: String
 } 
 
 type Result {
@@ -27,4 +28,30 @@ type Details{
   password: String
   createdAt: String
   originalId: String
+}
+
+type NewRES {
+message: String
+data1: [RES]
+}
+
+type RES {
+    name: String!
+    email: String!
+    _id: ID!
+    role: String
+    password: String!
+    originalId: String
+}
+
+type Delete {
+  status: String
+  message: String
+  data: DATA
+}
+
+type DATA {
+  name: String
+  originalId: String
+  email: String
 }

--- a/src/modules/user/types.graphql
+++ b/src/modules/user/types.graphql
@@ -3,4 +3,5 @@ type User {
     email: String!
     id: ID!
     role: String
+    password: String!
 } 

--- a/src/modules/user/types.graphql
+++ b/src/modules/user/types.graphql
@@ -20,6 +20,11 @@ type Alltrainees{
   record: [Details]
 }
 
+type NewRES {
+message: String
+data1: [Details]
+}
+
 type Details{
   name: String
   _id: String
@@ -30,19 +35,7 @@ type Details{
   originalId: String
 }
 
-type NewRES {
-message: String
-data1: [RES]
-}
 
-type RES {
-    name: String!
-    email: String!
-    _id: ID!
-    role: String
-    password: String!
-    originalId: String
-}
 
 type Delete {
   status: String

--- a/src/modules/user/types.graphql
+++ b/src/modules/user/types.graphql
@@ -5,3 +5,9 @@ type User {
     role: String
     password: String!
 } 
+
+type Result {
+  message: String
+  status: Int
+  data: String
+}

--- a/src/modules/user/types.graphql
+++ b/src/modules/user/types.graphql
@@ -26,4 +26,5 @@ type Details{
   email: String
   password: String
   createdAt: String
+  originalId: String
 }

--- a/src/modules/user/types.graphql
+++ b/src/modules/user/types.graphql
@@ -11,3 +11,19 @@ type Result {
   status: Int
   data: String
 }
+
+type Alltrainees{
+  message: String
+  totalCount: Int
+  traineeCount: Int
+  record: [Details]
+}
+
+type Details{
+  name: String
+  _id: String
+  role: String
+  email: String
+  password: String
+  createdAt: String
+}

--- a/src/server.js
+++ b/src/server.js
@@ -1,7 +1,7 @@
 import Express from 'express';
 import { ApolloServer } from 'apollo-server-express';
 import { createServer } from 'http';
-import { UserAPI } from './datasource/index';
+import { UserAPI, TraineeAPI } from './datasource/index';
 // import TraineeAPI from './modules/trainee/query';
 
 class Server {
@@ -29,7 +29,14 @@ class Server {
       ...schema,
       dataSources: () => {
         const userAPI = new UserAPI();
-        return { userAPI };
+        const traineeAPI = new TraineeAPI();
+        return { userAPI, traineeAPI };
+      },
+      context: ({ req }) => {
+        if (req) {
+          return { token: req.headers.authorization };
+        }
+        return {};
       }
     });
     this.Server.applyMiddleware({ app });

--- a/src/server.js
+++ b/src/server.js
@@ -1,6 +1,8 @@
 import Express from 'express';
 import { ApolloServer } from 'apollo-server-express';
 import { createServer } from 'http';
+import { UserAPI } from './datasource/index';
+// import TraineeAPI from './modules/trainee/query';
 
 class Server {
   constructor(config) {
@@ -24,7 +26,11 @@ class Server {
   setupApollo(schema) {
     const { app } = this;
     this.Server = new ApolloServer({
-      ...schema
+      ...schema,
+      dataSources: () => {
+        const userAPI = new UserAPI();
+        return { userAPI };
+      }
     });
     this.Server.applyMiddleware({ app });
     this.httpServer = createServer(app);

--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,6 @@
 import Express from 'express';
 import { ApolloServer } from 'apollo-server-express';
+import { createServer } from 'http';
 
 class Server {
   constructor(config) {
@@ -26,13 +27,15 @@ class Server {
       ...schema
     });
     this.Server.applyMiddleware({ app });
+    this.httpServer = createServer(app);
+    this.Server.installSubscriptionHandlers(this.httpServer);
     this.run();
   }
 
   run() {
     const { config: { port } } = this;
-    const { app } = this;
-    app.listen(port, (err) => {
+    // const { app } = this;
+    this.httpServer.listen(port, (err) => {
       if (err) {
         // eslint-disable-next-line no-console
         console.log(err);

--- a/src/service/user.js
+++ b/src/service/user.js
@@ -5,7 +5,7 @@ class User {
   }
 
   getAllUsers() {
-    return this.users.values;
+    return this.users.values();
   }
 
   createUser(user) {


### PR DESCRIPTION
AC
- Add the trainee data source and add all the methods in there with respect to the available rest endpoints for trainees.
- Update the schema of the entities with respect to the response of the above APIs.
- Replace the mock implementation calls with actual API calls in your resolvers.

Steps:
- Add the context key in the Apollo Server instance, where you will get the token from the req header and return that token from 
  there so that it is available in context.
- Add a function in your data source willSendRequest where you will set the header of the request which you will get from the 
  context.
Now as the last step make all changes according to the acceptance criteria.
